### PR TITLE
chore: JDK 25 へアップグレード

### DIFF
--- a/.cursor/architecture.md
+++ b/.cursor/architecture.md
@@ -15,7 +15,7 @@
 
 ### `mcp/` (Server Application)
 MCPサーバーのコアロジックを担当するバックエンドアプリケーションです。
-- **言語**: Kotlin (JDK 21)
+- **言語**: Kotlin (JDK 25)
 - **フレームワーク**: Spring Boot 3.2+ (Spring WebFlux)
 - **アーキテクチャ**: オニオンアーキテクチャ (DDD)
 - **通信プロトコル**: Server-Sent Events (SSE) for MCP transport

--- a/.github/workflows/mcp-ci.yml
+++ b/.github/workflows/mcp-ci.yml
@@ -19,10 +19,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
-          java-version: "21"
+          java-version: "25"
           distribution: "temurin"
           cache: gradle
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -7,7 +7,7 @@
 
 以下のツールがインストールされていることを確認してください。
 
-- **Java**: JDK 21+ (`java -version`)
+- **Java**: JDK 25+ (`java -version`)
 - **Go**: 1.22+ (`go version`)
 - **Python**: 3.12+ & `uv` (`uv --version`)
 - **Cloud CLI**:

--- a/mcp/build.gradle.kts
+++ b/mcp/build.gradle.kts
@@ -1,13 +1,13 @@
 plugins {
-	kotlin("jvm") version "2.2.21"
-	kotlin("plugin.spring") version "2.2.21"
+	kotlin("jvm") version "2.3.0"
+	kotlin("plugin.spring") version "2.3.0"
 	id("org.springframework.boot") version "4.0.2"
 	id("io.spring.dependency-management") version "1.1.7"
 	jacoco
 }
 
 jacoco {
-	toolVersion = "0.8.11"
+	toolVersion = "0.8.14"
 }
 
 group = "com.example"
@@ -16,7 +16,7 @@ description = "Demo project for Spring Boot"
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
+		languageVersion = JavaLanguageVersion.of(25)
 	}
 }
 


### PR DESCRIPTION
# JDK 25 へのアップグレード

## 概要

利用する JDK を 21 から 25 に上げ、Gradle の Java toolchain・CI・ドキュメントを合わせて更新しました。JDK 25 対応のため Kotlin と JaCoCo のバージョンも上げています。

## 変更内容

### 1. `mcp/build.gradle.kts`

| 項目 | 変更前 | 変更後 | 理由 |
|------|--------|--------|------|
| Java toolchain | `JavaLanguageVersion.of(21)` | `JavaLanguageVersion.of(25)` | JDK 25 を利用するため |
| Kotlin | 2.2.21 | **2.3.0** | Kotlin 2.2 は JVM target 25 非対応のため（2.3.0 で Java 25 対応） |
| JaCoCo | 0.8.11 | **0.8.14** | class file version 69 (Java 25) 対応のため |

### 2. `.github/workflows/mcp-ci.yml`

- **Set up JDK 21** → **Set up JDK 25**
- `java-version: "21"` → `java-version: "25"`
- distribution は `temurin` のまま（Temurin は JDK 25 をサポート）

### 3. ドキュメント

- **docs/DEVELOPMENT.md**: 前提条件を「JDK 21+」→「JDK 25+」に更新
- **.cursor/architecture.md**: 技術スタック表記を「Kotlin (JDK 21)」→「Kotlin (JDK 25)」に更新

## 動作確認

- `cd mcp && ./gradlew build --no-daemon` … 成功
- `./gradlew compileKotlin compileTestKotlin --no-daemon` … 成功（CI と同様の Lint）

ローカルで JDK 25 を利用してビルド・テスト・JaCoCo レポートまで問題なく完了しています。
