### PR TITLE
feat(client): install コマンド実装と Claude Desktop 向け JSON-RPC id 正規化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # PR 説明文（gh pr create の --body-file 用のローカルメモ）
 docs/PULL_REQUEST.md
+docs/PR_*.md
 
 .idea
 

--- a/client/README.md
+++ b/client/README.md
@@ -45,13 +45,26 @@ go run ./cmd/mcp-bridge connect --url http://localhost:8080/sse --debug
 3. 標準入力に 1 行で JSON-RPC を送る（例: `echo '{"jsonrpc":"2.0","method":"initialize","params":{},"id":1}' | go run ./cmd/mcp-bridge connect`）。
 4. 標準出力に JSON-RPC レスポンスが返れば疎通成功です。
 
-### install（プレースホルダー）
+### install（Claude Desktop への登録）
 
-Claude Desktop の設定ファイルを書き換える枠組みです。未実装です。
+Claude Desktop の設定ファイル（`claude_desktop_config.json`）を更新し、この MCP サーバーを登録します。設定ファイルやディレクトリが存在しない場合は自動作成します。実行後は Claude Desktop の再起動が必要です。
 
 ```bash
 go run ./cmd/mcp-bridge install
 ```
+
+- `--url`: MCP サーバーの URL（デフォルト: `http://localhost:8080/sse`）
+- `--profile`: AWS プロファイル名（Claude の環境変数に注入、デフォルト: `default`）
+
+例: 別 URL とプロファイルを指定する場合
+
+```bash
+go run ./cmd/mcp-bridge install --url http://localhost:9090/sse --profile myprofile
+```
+
+設定ファイルのパス（OS により自動判定）:
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
 
 ## 設定
 

--- a/client/cmd/mcp-bridge/install.go
+++ b/client/cmd/mcp-bridge/install.go
@@ -2,22 +2,41 @@ package main
 
 import (
 	"fmt"
+	"os"
 
+	"github.com/otajisan/vertex-ai-search-mcp-prototype/client/internal/config"
+	"github.com/otajisan/vertex-ai-search-mcp-prototype/client/internal/installer"
 	"github.com/spf13/cobra"
+)
+
+var (
+	installURL    string
+	installProfile string
 )
 
 var installCmd = &cobra.Command{
 	Use:   "install",
-	Short: "Install or update Claude Desktop config to use mcp-bridge (placeholder)",
-	Long:  "This command will locate Claude Desktop config file and add mcp-bridge as an MCP server. Not yet implemented.",
+	Short: "Install or update Claude Desktop config to use mcp-bridge",
+	Long:  "Updates claude_desktop_config.json to register this MCP server. Creates the config file and directory if they do not exist.",
 	RunE:  runInstall,
 }
 
+func init() {
+	installCmd.Flags().StringVar(&installURL, "url", config.DefaultSSEURL, "MCP server URL (e.g. http://localhost:8080/sse)")
+	installCmd.Flags().StringVar(&installProfile, "profile", "default", "AWS profile name to inject into Claude Desktop env")
+}
+
 func runInstall(_ *cobra.Command, _ []string) error {
-	// プレースホルダー: 将来、internal/installer で実装する
-	// - runtime.GOOS で macOS / Windows を判別
-	// - macOS: ~/Library/Application Support/Claude/claude_desktop_config.json
-	// - Windows: %APPDATA%\Claude\claude_desktop_config.json
-	fmt.Println("install: placeholder — Claude Desktop config update will be implemented here.")
+	binaryPath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("実行バイナリのパス取得に失敗しました: %w", err)
+	}
+
+	svc := &installer.Service{}
+	if err := svc.Install(installURL, installProfile, binaryPath); err != nil {
+		return err
+	}
+
+	fmt.Println("設定を更新しました。Claude Desktop を再起動してください。")
 	return nil
 }

--- a/client/cmd/mcp-bridge/install.go
+++ b/client/cmd/mcp-bridge/install.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	installURL    string
+	installURL     string
 	installProfile string
 )
 

--- a/client/internal/installer/service.go
+++ b/client/internal/installer/service.go
@@ -1,0 +1,127 @@
+package installer
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+const (
+	// ServerKey は claude_desktop_config.json の mcpServers に追加するキー名です。
+	ServerKey = "vertex-ai-rag"
+)
+
+// Service は Claude Desktop 設定ファイルの更新を行います。
+type Service struct {
+	// ConfigPath は書き換え対象の設定ファイルの絶対パス。
+	// 空の場合は ConfigPathByOS() で決定したパスを使用する。
+	ConfigPath string
+}
+
+// ConfigPathByOS は runtime.GOOS に応じた Claude Desktop 設定ファイルのパスを返します。
+// ファイルが存在しない場合でもパスは返します。呼び出し側で新規作成してください。
+// - windows: %APPDATA%\Claude\claude_desktop_config.json
+// - darwin (macOS): ~/Library/Application Support/Claude/claude_desktop_config.json
+// 上記以外の OS では darwin と同じパスを返します。
+// Windows で APPDATA が未設定の場合はエラーを返します。
+func ConfigPathByOS() (string, error) {
+	switch runtime.GOOS {
+	case "windows":
+		appdata := os.Getenv("APPDATA")
+		if appdata == "" {
+			return "", fmt.Errorf("APPDATA が設定されていません。Windows では Claude Desktop 設定のパスを特定できません")
+		}
+		return filepath.Join(appdata, "Claude", "claude_desktop_config.json"), nil
+	default:
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("ホームディレクトリの取得に失敗しました: %w", err)
+		}
+		return filepath.Join(home, "Library", "Application Support", "Claude", "claude_desktop_config.json"), nil
+	}
+}
+
+// Install は設定ファイルを読み込み、mcpServers に vertex-ai-rag エントリを追加または上書きして保存します。
+// serverURL は MCP サーバーの URL（例: http://localhost:8080/sse）、profile は AWS プロファイル名です。
+// binaryPath は command に設定する mcp-bridge バイナリの絶対パス（通常は os.Executable() の戻り値）です。
+func (s *Service) Install(serverURL, profile, binaryPath string) error {
+	configPath := s.ConfigPath
+	if configPath == "" {
+		p, err := ConfigPathByOS()
+		if err != nil {
+			return err
+		}
+		configPath = p
+	}
+
+	dir := filepath.Dir(configPath)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("設定ディレクトリの作成に失敗しました (%s): %w", dir, err)
+	}
+
+	root, err := s.readConfig(configPath)
+	if err != nil {
+		return err
+	}
+
+	mcpServers, _ := root["mcpServers"].(map[string]interface{})
+	if mcpServers == nil {
+		mcpServers = make(map[string]interface{})
+		root["mcpServers"] = mcpServers
+	}
+
+	mcpServers[ServerKey] = map[string]interface{}{
+		"command": binaryPath,
+		"args":    []interface{}{"connect", "--url", serverURL},
+		"env": map[string]interface{}{
+			"AWS_PROFILE": profile,
+		},
+	}
+
+	if err := s.writeConfig(configPath, root); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *Service) readConfig(path string) (map[string]interface{}, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return make(map[string]interface{}), nil
+		}
+		if os.IsPermission(err) {
+			return nil, fmt.Errorf("設定ファイルの読み取り権限がありません: %s", path)
+		}
+		return nil, fmt.Errorf("設定ファイルの読み取りに失敗しました: %w", err)
+	}
+
+	var root map[string]interface{}
+	if len(data) == 0 {
+		return make(map[string]interface{}), nil
+	}
+	if err := json.Unmarshal(data, &root); err != nil {
+		return nil, fmt.Errorf("設定ファイルの JSON 解析に失敗しました: %w", err)
+	}
+	if root == nil {
+		root = make(map[string]interface{})
+	}
+	return root, nil
+}
+
+func (s *Service) writeConfig(path string, root map[string]interface{}) error {
+	data, err := json.MarshalIndent(root, "", "  ")
+	if err != nil {
+		return fmt.Errorf("設定の JSON 出力に失敗しました: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		if os.IsPermission(err) {
+			return fmt.Errorf("設定ファイルの書き込み権限がありません: %s", path)
+		}
+		return fmt.Errorf("設定ファイルの書き込みに失敗しました: %w", err)
+	}
+	return nil
+}

--- a/client/internal/installer/service_test.go
+++ b/client/internal/installer/service_test.go
@@ -1,0 +1,184 @@
+package installer
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestService_Install(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "claude_desktop_config.json")
+	binaryPath := filepath.Join(dir, "mcp-bridge")
+
+	tests := []struct {
+		name       string
+		initial    string
+		url        string
+		profile    string
+		wantKey    string
+		wantCmd    string
+		wantArgs   []interface{}
+		wantEnv    map[string]interface{}
+		preserve   string // このキーが既存 JSON にあった場合、残っていることを確認する
+	}{
+		{
+			name:     "empty file creates mcpServers and vertex-ai-rag",
+			initial:  "",
+			url:      "http://localhost:8080/sse",
+			profile:  "default",
+			wantKey:  ServerKey,
+			wantCmd:  binaryPath,
+			wantArgs: []interface{}{"connect", "--url", "http://localhost:8080/sse"},
+			wantEnv:  map[string]interface{}{"AWS_PROFILE": "default"},
+		},
+		{
+			name:     "existing mcpServers merged",
+			initial:  `{"mcpServers":{"other":{"command":"other"}}}`,
+			url:      "http://example.com/sse",
+			profile:  "myprofile",
+			wantKey:  ServerKey,
+			wantCmd:  binaryPath,
+			wantArgs: []interface{}{"connect", "--url", "http://example.com/sse"},
+			wantEnv:  map[string]interface{}{"AWS_PROFILE": "myprofile"},
+			preserve: "other",
+		},
+		{
+			name:     "overwrites existing vertex-ai-rag",
+			initial:  `{"mcpServers":{"vertex-ai-rag":{"command":"old"}}}`,
+			url:      "http://new:9090/sse",
+			profile:  "default",
+			wantKey:  ServerKey,
+			wantCmd:  binaryPath,
+			wantArgs: []interface{}{"connect", "--url", "http://new:9090/sse"},
+			wantEnv:  map[string]interface{}{"AWS_PROFILE": "default"},
+		},
+		{
+			name:     "preserves top-level keys",
+			initial:  `{"theme":"dark"}`,
+			url:      "http://localhost:8080/sse",
+			profile:  "default",
+			wantKey:  ServerKey,
+			wantCmd:  binaryPath,
+			wantArgs: []interface{}{"connect", "--url", "http://localhost:8080/sse"},
+			wantEnv:  map[string]interface{}{"AWS_PROFILE": "default"},
+			preserve: "theme",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.initial != "" {
+				if err := os.WriteFile(configPath, []byte(tt.initial), 0600); err != nil {
+					t.Fatalf("write initial: %v", err)
+				}
+			}
+
+			svc := &Service{ConfigPath: configPath}
+			if err := svc.Install(tt.url, tt.profile, binaryPath); err != nil {
+				t.Fatalf("Install() error = %v", err)
+			}
+
+			data, err := os.ReadFile(configPath)
+			if err != nil {
+				t.Fatalf("read config: %v", err)
+			}
+			var root map[string]interface{}
+			if err := json.Unmarshal(data, &root); err != nil {
+				t.Fatalf("parse config: %v", err)
+			}
+
+			mcp, ok := root["mcpServers"].(map[string]interface{})
+			if !ok || mcp == nil {
+				t.Fatal("mcpServers missing or not object")
+			}
+			ent, ok := mcp[tt.wantKey].(map[string]interface{})
+			if !ok || ent == nil {
+				t.Fatalf("mcpServers[%q] missing or not object", tt.wantKey)
+			}
+			if cmd, _ := ent["command"].(string); cmd != tt.wantCmd {
+				t.Errorf("command = %q, want %q", cmd, tt.wantCmd)
+			}
+			args, _ := ent["args"].([]interface{})
+			if len(args) != len(tt.wantArgs) {
+				t.Errorf("args len = %d, want %d", len(args), len(tt.wantArgs))
+			} else {
+				for i := range args {
+					if args[i] != tt.wantArgs[i] {
+						t.Errorf("args[%d] = %v, want %v", i, args[i], tt.wantArgs[i])
+					}
+				}
+			}
+			env, _ := ent["env"].(map[string]interface{})
+			for k, v := range tt.wantEnv {
+				if env[k] != v {
+					t.Errorf("env[%q] = %v, want %v", k, env[k], v)
+				}
+			}
+
+			if tt.preserve != "" {
+				if _, inMcp := mcp[tt.preserve]; inMcp {
+					// preserved inside mcpServers
+					return
+				}
+				if _, atRoot := root[tt.preserve]; atRoot {
+					return
+				}
+				t.Errorf("preserved key %q not found in output", tt.preserve)
+			}
+		})
+	}
+}
+
+func TestService_Install_createsDir(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "sub", "claude_desktop_config.json")
+	binaryPath := filepath.Join(dir, "mcp-bridge")
+
+	svc := &Service{ConfigPath: configPath}
+	if err := svc.Install("http://localhost:8080/sse", "default", binaryPath); err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	if _, err := os.Stat(configPath); err != nil {
+		t.Fatalf("config file not created: %v", err)
+	}
+}
+
+func TestService_Install_invalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "claude_desktop_config.json")
+	if err := os.WriteFile(configPath, []byte(`{invalid`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	svc := &Service{ConfigPath: configPath}
+	err := svc.Install("http://localhost:8080/sse", "default", filepath.Join(dir, "mcp-bridge"))
+	if err == nil {
+		t.Fatal("Install() expected error for invalid JSON")
+	}
+}
+
+func TestConfigPathByOS(t *testing.T) {
+	path, err := ConfigPathByOS()
+	if err != nil {
+		t.Fatalf("ConfigPathByOS() error = %v", err)
+	}
+	if path == "" {
+		t.Fatal("ConfigPathByOS() returned empty path")
+	}
+	switch runtime.GOOS {
+	case "windows":
+		if filepath.Base(path) != "claude_desktop_config.json" {
+			t.Errorf("path = %q, want filename claude_desktop_config.json", path)
+		}
+	default:
+		if filepath.Base(path) != "claude_desktop_config.json" {
+			t.Errorf("path = %q, want filename claude_desktop_config.json", path)
+		}
+		// darwin: .../Library/Application Support/Claude/...
+		if !strings.Contains(path, "Claude") {
+			t.Errorf("path should contain Claude: %q", path)
+		}
+	}
+}

--- a/client/internal/installer/service_test.go
+++ b/client/internal/installer/service_test.go
@@ -15,15 +15,15 @@ func TestService_Install(t *testing.T) {
 	binaryPath := filepath.Join(dir, "mcp-bridge")
 
 	tests := []struct {
-		name       string
-		initial    string
-		url        string
-		profile    string
-		wantKey    string
-		wantCmd    string
-		wantArgs   []interface{}
-		wantEnv    map[string]interface{}
-		preserve   string // このキーが既存 JSON にあった場合、残っていることを確認する
+		wantEnv  map[string]interface{}
+		name     string
+		initial  string
+		url      string
+		profile  string
+		wantKey  string
+		wantCmd  string
+		preserve string // このキーが既存 JSON にあった場合、残っていることを確認する
+		wantArgs []interface{}
 	}{
 		{
 			name:     "empty file creates mcpServers and vertex-ai-rag",


### PR DESCRIPTION
# クライアント: install コマンド実装と Claude Desktop 向け JSON-RPC 正規化

Closes #7

## 概要

- **install コマンド**: Claude Desktop の `claude_desktop_config.json` を自動作成・更新し、mcp-bridge を MCP サーバーとして登録する機能を実装しました。
- **Claude Desktop 互換**: Claude が受け付けない JSON-RPC の `id: null` を正規化し、エラー時も Zod 検証を通るようにしました。

## 変更内容

### 1. install コマンド（Issue #7 対応）

| ファイル | 説明 |
|----------|------|
| `client/internal/installer/service.go` | 設定ファイルパスの OS 判定（`ConfigPathByOS`）、`mcpServers.vertex-ai-rag` の追加・上書き（`Install`）。ディレクトリ自動作成、既存キーは保持。 |
| `client/internal/installer/service_test.go` | 一時ディレクトリを使ったテーブル駆動テスト（空ファイル／既存 mcpServers／上書き／他キー保持／不正 JSON）。 |
| `client/cmd/mcp-bridge/install.go` | `--url`（デフォルト: `http://localhost:8080/sse`）、`--profile`（デフォルト: `default`）を定義し、`installer.Service.Install` を呼び出し。成功時に「Claude Desktop を再起動してください」と表示。 |

- **設定ファイルパス**: macOS は `~/Library/Application Support/Claude/claude_desktop_config.json`、Windows は `%APPDATA%\Claude\claude_desktop_config.json`。
- **登録内容**: `command` に `os.Executable()` の絶対パス、`args` に `["connect", "--url", "<url>"]`、`env` に `AWS_PROFILE: "<profile>"`。

### 2. Claude Desktop 向け JSON-RPC id 正規化

| ファイル | 説明 |
|----------|------|
| `client/internal/proxy/proxy.go` | ブリッジおよびサーバーからのレスポンスで `id` が欠損・`null` の場合に `0` を設定してから stdout に転送。 |

- **経緯**: Claude Desktop は JSON-RPC の `id` に string または number のみ許容し、`null` を送ると Zod で「Invalid input」「Unrecognized key(s): 'error'」となる。
- **対応**:
  - ブリッジ発のエラー: リクエスト行から `extractRequestID` で `id` を取得し、`sendError` に渡す（取得できない場合は `0`）。
  - サーバー応答の転送: POST 応答・SSE の data を `normalizeResponseID` で正規化し、`result`/`error` がありかつ `id` が無い・`null`・非 string/number のとき `id: 0` を設定してから転送。

### 3. その他

- **`.gitignore`**: `docs/PR_*.md` を追加（PR 本文用ローカルメモをリポジトリに含めないため）。
- **`client/README.md`**: install の使い方（`--url` / `--profile`、設定ファイルパス）を追記。

## 動作確認

- `go test ./...`（client）: 成功。
- `mcp-bridge install` 実行後、Claude Desktop で MCP サーバーを利用可能であることを確認済み。

Made with [Cursor](https://cursor.com)